### PR TITLE
New Example: An interface to combine historical and live table access

### DIFF
--- a/examples/misc/combined_table/README.md
+++ b/examples/misc/combined_table/README.md
@@ -1,0 +1,20 @@
+# A combined historical and live table
+
+This directory provides an implementation for a combined historical and live table.  
+The combined table can be used with either a Deephaven server or client.
+
+Key features of the combined table include:
+* Specific table method overrides are provided to keep historical and live tables separate as long as possible to maintain indexing.
+* All other methods are passed through to the combined table.
+* `where` has an additional argument that allows you to specify whether to immediately apply the filter to the historical or live table or defer the application.
+
+If you would like to add further performance optimizations to `CombinedTable`, you just need to override
+table methods in the `CombinedTable` class to handle the specific cases.
+
+## Files
+
+* [./combined_table_common.py](./combined_table_common.py) - The common code for the combined table.
+* [./combined_table_server.py](./combined_table_server.py) - The server-side implementation of the combined table.
+* [./combined_table_client.py](./combined_table_client.py) - The client-side implementation of the combined table.
+* [./test_server.py](./test_server.py) - A test/example script for the server-side implementation.
+* [./test_client.py](./test_client.py) - A test/example script for the client-side implementation.

--- a/examples/misc/combined_table/combined_table_client.py
+++ b/examples/misc/combined_table/combined_table_client.py
@@ -45,4 +45,4 @@ def combined_table(session: Session, namespace: str, table_name: str) -> Combine
     """
     hist = _db_table(session, namespace, table_name, is_live=False)
     live = _db_table(session, namespace, table_name, is_live=True)
-    return CombinedTable(session.merge, hist, live, hist_filters=["Date < today()"], live_filters=["Date = today()"])
+    return CombinedTable(session.merge_tables, hist, live, hist_filters=["Date < today()"], live_filters=["Date = today()"])

--- a/examples/misc/combined_table/combined_table_client.py
+++ b/examples/misc/combined_table/combined_table_client.py
@@ -1,0 +1,48 @@
+
+""" A package that provides a CombinedTable class for pydeephaven clients
+that combines a historical and live table into a single table.
+
+See: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
+"""
+
+import random
+
+from combined_table_common import CombinedTable
+from pydeephaven import Session, Table
+
+
+def _db_table(session: Session, namespace: str, table_name: str, is_live: bool) -> Table:
+    """ Get a table from the database on the server.
+
+    Args:
+        session: The session to use.
+        namespace: The namespace of the table.
+        table_name: The name of the table.
+        is_live: True for live table, False for historical table.
+    """
+    tid = random.randint(0, 1000000)
+    session.run_script(
+        f"""_temp_{tid} = db.{"live_table" if is_live else "historical_table"}("{namespace}", "{table_name}")"""
+    )
+    t = session.open_table(f"_temp_{id}")
+    session.run_script(f"""del _temp_{id}""")
+    return t
+
+
+def combined_table(session: Session, namespace: str, table_name: str) -> CombinedTable:
+    """ Create a combined table for the given namespace and table name.
+
+    The live table is for today according to `today()`.
+    The historical table is for all dates less than today.
+
+    Args:
+        session: The session to use.
+        namespace: The namespace of the table.
+        table_name: The name of the table.
+
+    Returns:
+        A CombinedTable object.
+    """
+    hist = _db_table(session, namespace, table_name, is_live=False)
+    live = _db_table(session, namespace, table_name, is_live=True)
+    return CombinedTable(session.merge, hist, live, hist_filters=["Date < today()"], live_filters=["Date = today()"])

--- a/examples/misc/combined_table/combined_table_client.py
+++ b/examples/misc/combined_table/combined_table_client.py
@@ -5,7 +5,7 @@ that combines a historical and live table into a single table.
 See: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
 """
 
-import random
+from uuid import uuid4
 
 from combined_table_common import CombinedTable
 from pydeephaven import Session, Table
@@ -20,7 +20,7 @@ def _db_table(session: Session, namespace: str, table_name: str, is_live: bool) 
         table_name: The name of the table.
         is_live: True for live table, False for historical table.
     """
-    tid = random.randint(0, 1000000)
+    tid = uuid4().int
     session.run_script(
         f"""_temp_{tid} = db.{"live_table" if is_live else "historical_table"}("{namespace}", "{table_name}")"""
     )

--- a/examples/misc/combined_table/combined_table_client.py
+++ b/examples/misc/combined_table/combined_table_client.py
@@ -24,8 +24,8 @@ def _db_table(session: Session, namespace: str, table_name: str, is_live: bool) 
     session.run_script(
         f"""_temp_{tid} = db.{"live_table" if is_live else "historical_table"}("{namespace}", "{table_name}")"""
     )
-    t = session.open_table(f"_temp_{id}")
-    session.run_script(f"""del _temp_{id}""")
+    t = session.open_table(f"_temp_{tid}")
+    session.run_script(f"""del _temp_{tid}""")
     return t
 
 

--- a/examples/misc/combined_table/combined_table_common.py
+++ b/examples/misc/combined_table/combined_table_common.py
@@ -92,17 +92,15 @@ class CombinedTable(Generic[Table]):
 
     # If the method doesn't exist in this object, delegate it to the combined table.
     # Methods are called with other CombinedTable objects as arguments, the arguments are converted to Table objects.
-    def __getattr__(*args):
-        obj = args[0]
-        fn = args[1]
-        c = obj.combined
-        f = getattr(c, fn)
+    def __getattr__(self, attr):
+        c = self.combined
+        a = getattr(c, attr)
 
         # This is to handle @property methods and properties
-        if not callable(f):
-            return f
+        if not callable(a):
+            return a
 
-        return CombinedTable._args_to_table_decorator(f)
+        return CombinedTable._args_to_table_decorator(a)
 
     @staticmethod
     def _combine_filters(filters1: Union[str, Sequence[str]], filters2: Union[str, Sequence[str]]) -> Optional[Sequence[str]]:

--- a/examples/misc/combined_table/combined_table_server.py
+++ b/examples/misc/combined_table/combined_table_server.py
@@ -6,12 +6,11 @@ from combined_table_common import CombinedTable
 
 from deephaven_enterprise.database import db
 from deephaven import merge
-from deephaven.time import dh_today
 
 def combined_table(namespace: str, table_name: str) -> CombinedTable:
     """ Create a combined table for the given namespace and table name.
 
-    The live table is for today according to deephaven.time.dh_today().
+    The live table is for today according to `today()`.
     The historical table is for all dates less than today.
 
     Args:
@@ -21,9 +20,7 @@ def combined_table(namespace: str, table_name: str) -> CombinedTable:
     Returns:
         A CombinedTable object.
     """
-    # noinspection PyUnusedLocal
-    date = dh_today()
     hist = db.historical_table(namespace, table_name)
     live = db.live_table(namespace, table_name)
-    return CombinedTable(merge, hist, live, hist_filters=["Date < date"], live_filters=["Date = date"])
+    return CombinedTable(merge, hist, live, hist_filters=["Date < today()"], live_filters=["Date = today()"])
 

--- a/examples/misc/combined_table/combined_table_server.py
+++ b/examples/misc/combined_table/combined_table_server.py
@@ -1,0 +1,29 @@
+
+""" A package that provides a CombinedTable class for the deephaven server
+that combines a historical and live table into a single table."""
+
+from combined_table_common import CombinedTable
+
+from deephaven_enterprise.database import db
+from deephaven import merge
+from deephaven.time import dh_today
+
+def combined_table(namespace: str, table_name: str) -> CombinedTable:
+    """ Create a combined table for the given namespace and table name.
+
+    The live table is for today according to deephaven.time.dh_today().
+    The historical table is for all dates less than today.
+
+    Args:
+        namespace: The namespace of the table.
+        table_name: The name of the table.
+
+    Returns:
+        A CombinedTable object.
+    """
+    # noinspection PyUnusedLocal
+    date = dh_today()
+    hist = db.historical_table(namespace, table_name)
+    live = db.live_table(namespace, table_name)
+    return CombinedTable(merge, hist, live, hist_filters=["Date < date"], live_filters=["Date = date"])
+

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -26,7 +26,7 @@ cta_hist = cta.historical
 cta_comb = cta.combined
 
 # test unspecified method routing
-print(ct.is_blink)
+print(ct.is_refreshing)
 
 # Test a where without applying
 f1 = ct.where("Date > `2024-04-09`", apply=False)

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -55,7 +55,7 @@ h4 = f4.head(3)
 assert(f4 == f3)
 
 # Test where_in with a table
-tf = empty_table(1).update("Date=`2024-04-09`")
+tf = session.empty_table(1).update("Date=`2024-04-09`")
 f5 = f1.where_in(tf, "Date")
 fc5 = f5.combined
 h5 = f5.head(3)

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -30,10 +30,15 @@ f1 = ct.where("Date > `2024-04-09`", apply=False)
 fc1 = f1.combined
 h1 = f1.head(3)
 
-# Test another where with applying
+# Test another where with applying (historical and live already computed)
 f2 = f1.where("Date < `2024-04-11`")
 fc2 = f2.combined
 h2 = f2.head(3)
+
+# Test another where with applying (historical and live not already computed)
+f2a = ct.where("Date > `2024-04-09`", apply=False).where("Date < `2024-04-11`")
+fc2a = f2a.combined
+h2a = f2a.head(3)
 
 # Test a where on an applied table
 f3 = f2.where("Date > `2024-04-01`")

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -5,6 +5,7 @@ from combined_table_client import combined_table
 from deephaven_enterprise.client.session_manager import SessionManager
 
 # For connection details, see: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
+
 connection_info = "https://hostname:8123/iris/connection.json"
 session_mgr: SessionManager = SessionManager(connection_info)
 

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -1,10 +1,17 @@
 
-# A script to test combined_table on the server
+# A script to test combined_table on the client
 
-from combined_table_server import combined_table
-from deephaven import empty_table
+from combined_table_client import combined_table
+from deephaven_enterprise.client.session_manager import SessionManager
 
-ct = combined_table("FeedOS", "EquityQuoteL1")
+# For connection details, see: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
+connection_info = "https://hostname:8123/iris/connection.json"
+session_mgr: SessionManager = SessionManager(connection_info)
+session_mgr.private_key("/path-to-private-key/priv-username.base64.txt")
+session = session_mgr.connect_to_new_worker(name=None, heap_size_gb=4.0)
+
+# Begin testing
+ct = combined_table(session, "FeedOS", "EquityQuoteL1")
 ct_live = ct.live
 ct_hist = ct.historical
 ct_comb = ct.combined
@@ -51,7 +58,7 @@ fc6 = f6.combined
 h6 = f6.head(3)
 
 # Test where_not_in with a table
-tf = empty_table(1).update("Date=`2024-04-09`")
+tf = session.empty_table(1).update("Date=`2024-04-09`")
 f7 = f1.where_not_in(tf, "Date")
 fc7 = f7.combined
 h7 = f7.head(3)

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -5,7 +5,7 @@ from combined_table_client import combined_table
 from deephaven_enterprise.client.session_manager import SessionManager
 
 # For connection details, see: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
-# connection_info = "https://hostname:8123/iris/connection.json"
+connection_info = "https://hostname:8123/iris/connection.json"
 session_mgr: SessionManager = SessionManager(connection_info)
 
 # Authenticate

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -5,9 +5,12 @@ from combined_table_client import combined_table
 from deephaven_enterprise.client.session_manager import SessionManager
 
 # For connection details, see: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
-connection_info = "https://hostname:8123/iris/connection.json"
+# connection_info = "https://hostname:8123/iris/connection.json"
+connection_info = "https://qa-vplus-java17-cluster-infra-1.int.illumon.com:8000/iris/connection.json"
+connection_info = "https://dh-prod-demo-infra-1.int.illumon.com:8123/iris/connection.json"
 session_mgr: SessionManager = SessionManager(connection_info)
-session_mgr.private_key("/path-to-private-key/priv-username.base64.txt")
+session_mgr.password("iris", "iris")
+# session_mgr.private_key("/path-to-private-key/priv-username.base64.txt")
 session = session_mgr.connect_to_new_worker(name=None, heap_size_gb=4.0)
 
 # Begin testing

--- a/examples/misc/combined_table/test_client.py
+++ b/examples/misc/combined_table/test_client.py
@@ -6,11 +6,13 @@ from deephaven_enterprise.client.session_manager import SessionManager
 
 # For connection details, see: https://deephaven.io/enterprise/docs/coreplus/coreplus-python-client/
 # connection_info = "https://hostname:8123/iris/connection.json"
-connection_info = "https://qa-vplus-java17-cluster-infra-1.int.illumon.com:8000/iris/connection.json"
-connection_info = "https://dh-prod-demo-infra-1.int.illumon.com:8123/iris/connection.json"
 session_mgr: SessionManager = SessionManager(connection_info)
-session_mgr.password("iris", "iris")
+
+# Authenticate
+session_mgr.password("username", "password")
+# -- or --
 # session_mgr.private_key("/path-to-private-key/priv-username.base64.txt")
+
 session = session_mgr.connect_to_new_worker(name=None, heap_size_gb=4.0)
 
 # Begin testing
@@ -76,10 +78,11 @@ f8 = f1.where_not_in(f3, "Date")
 fc8 = f8.combined
 h8 = f8.head(3)
 
-# Test where_one_of
-f9 = f1.where_one_of(["Date=`2024-04-09`", "Date=`2024-04-06`"])
-fc9 = f9.combined
-h9 = f9.head(3)
+# Not yet supported
+# # Test where_one_of
+# f9 = f1.where_one_of(["Date=`2024-04-09`", "Date=`2024-04-06`"])
+# fc9 = f9.combined
+# h9 = f9.head(3)
 
 # Test materializing input CombinedTables
 f10 = f2.natural_join(f2, ["Date", "Timestamp"], ["JAsk=Ask"])

--- a/examples/misc/combined_table/test_server.py
+++ b/examples/misc/combined_table/test_server.py
@@ -1,0 +1,18 @@
+
+# A script to test combined_table on the server
+
+from combined_table_server import combined_table
+
+ct = combined_table("FeedOS", "EquityQuoteL1")
+ct_live = ct.live
+ct_hist = ct.historical
+ct_comb = ct.combined
+# print(ct.is_replay) # Method does not exist
+print(ct.is_blink)
+f1 = ct.where("Date > `2024-04-09`")
+fc1 = f1.combined
+h1 = f1.head(3)
+
+f2 = f1.where("Date < `2024-04-11`")
+fc2 = f2.combined
+h2 = f2.head(3)

--- a/examples/misc/combined_table/test_server.py
+++ b/examples/misc/combined_table/test_server.py
@@ -16,7 +16,7 @@ cta_hist = cta.historical
 cta_comb = cta.combined
 
 # test unspecified method routing
-print(ct.is_blink)
+print(ct.is_refreshing)
 
 # Test a where without applying
 f1 = ct.where("Date > `2024-04-09`", apply=False)

--- a/examples/misc/combined_table/test_server.py
+++ b/examples/misc/combined_table/test_server.py
@@ -2,17 +2,69 @@
 # A script to test combined_table on the server
 
 from combined_table_server import combined_table
+from deephaven import empty_table
 
 ct = combined_table("FeedOS", "EquityQuoteL1")
 ct_live = ct.live
 ct_hist = ct.historical
 ct_comb = ct.combined
-# print(ct.is_replay) # Method does not exist
+
+# test apply
+cta = ct.apply
+cta_live = cta.live
+cta_hist = cta.historical
+cta_comb = cta.combined
+
+# test unspecified method routing
 print(ct.is_blink)
-f1 = ct.where("Date > `2024-04-09`")
+
+# Test a where without applying
+f1 = ct.where("Date > `2024-04-09`", apply=False)
 fc1 = f1.combined
 h1 = f1.head(3)
 
+# Test another where with applying
 f2 = f1.where("Date < `2024-04-11`")
 fc2 = f2.combined
 h2 = f2.head(3)
+
+# Test a where on an applied table
+f3 = f2.where("Date > `2024-04-01`")
+fc3 = f3.combined
+h3 = f3.head(3)
+
+# Test where with no filters
+f4 = f3.where()
+fc4 = f4.combined
+h4 = f4.head(3)
+assert(f4 == f3)
+
+# Test where_in with a table
+tf = empty_table(1).update("Date=`2024-04-09`")
+f5 = f1.where_in(tf, "Date")
+fc5 = f5.combined
+h5 = f5.head(3)
+
+# Test where_in with a CombinedTable
+f6 = f1.where_in(f3, "Date")
+fc6 = f6.combined
+h6 = f6.combined
+
+# Test where_not_in with a table
+tf = empty_table(1).update("Date=`2024-04-09`")
+f7 = f1.where_not_in(tf, "Date")
+fc7 = f7.combined
+h7 = f7.head(3)
+
+# Test where_in with a CombinedTable
+f8 = f1.where_not_in(f3, "Date")
+fc8 = f8.combined
+h8 = f8.combined
+
+# Test where_one_of
+f9 = f1.where_one_of(["Date=`2024-04-09`", "Date=`2024-04-06`"])
+fc9 = f9.combined
+h9 = f9.head(3)
+
+# Test materializing input CombinedTables
+f10 = f2.natural_join(f2, ["Date", "Timestamp"], ["JAsk=Ask"])

--- a/examples/misc/combined_table/test_server.py
+++ b/examples/misc/combined_table/test_server.py
@@ -23,10 +23,15 @@ f1 = ct.where("Date > `2024-04-09`", apply=False)
 fc1 = f1.combined
 h1 = f1.head(3)
 
-# Test another where with applying
+# Test another where with applying (historical and live already computed)
 f2 = f1.where("Date < `2024-04-11`")
 fc2 = f2.combined
 h2 = f2.head(3)
+
+# Test another where with applying (historical and live not already computed)
+f2a = ct.where("Date > `2024-04-09`", apply=False).where("Date < `2024-04-11`")
+fc2a = f2a.combined
+h2a = f2a.head(3)
 
 # Test a where on an applied table
 f3 = f2.where("Date > `2024-04-01`")

--- a/examples/misc/dhe_combined_hist_live_table.py
+++ b/examples/misc/dhe_combined_hist_live_table.py
@@ -1,0 +1,110 @@
+
+""" A package that provides a CombinedTable class that combines a historical and live table into a single table."""
+
+from typing import Union, Sequence
+from deephaven_enterprise.database import db
+from deephaven import merge
+from deephaven.table import Table, Filter
+from deephaven.time import dh_today
+
+class CombinedTable:
+    """ A class that combines a historical and live table into a single table.
+    This class is used to provide a single interface to both tables.
+
+    Overrides of table methods are provided to optimize performance.
+    If a performance optimizing override is not provided, the method call is delegated to the combined table.
+    """
+    def __init__(self, hist: Table, live: Table):
+        self._historical = hist
+        self._live = live
+        self._combined = None
+
+    @property
+    def historical(self):
+        """ The historical table."""
+        return self._historical
+
+    @property
+    def live(self):
+        """ The live table."""
+        return self._live
+
+    @property
+    def combined(self):
+        """ The combined table."""
+        if not self._combined:
+            self._combined = merge([self._historical, self._live])
+
+        return self._combined
+
+    # If the method doesn't exist in this object, delegate it to the combined table.
+    def __getattr__(*args):
+        print(f"GETATTR: {args}")
+        obj = args[0]
+        fn = args[1]
+        c = obj.combined
+        return getattr(c, fn)
+
+    def where(self, filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None) -> 'CombinedTable':
+        print("DELEGATED: where")
+        return CombinedTable(
+            self._historical.where(filters),
+            self._live.where(filters)
+        )
+
+    def where_in(self, filter_table: Table, cols: Union[str, Sequence[str]]) -> 'CombinedTable':
+        print("DELEGATED: where_in")
+        return CombinedTable(
+            self._historical.where_in(filter_table, cols),
+            self._live.where_in(filter_table, cols)
+        )
+
+    def where_not_in(self, filter_table: Table, cols: Union[str, Sequence[str]]) -> 'CombinedTable':
+        print("DELEGATED: where_not_in")
+        return CombinedTable(
+            self._historical.where_not_in(filter_table, cols),
+            self._live.where_not_in(filter_table, cols)
+        )
+
+    def where_one_of(self, filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None) -> 'CombinedTable':
+        print("DELEGATED: where_one_of")
+        return CombinedTable(
+            self._historical.where_one_of(filters),
+            self._live.where_one_of(filters)
+        )
+
+
+def combined_table(namespace:str, table_name:str) -> CombinedTable:
+    """ Create a combined table for the given namespace and table name.
+
+    The live table is for today according to deephaven.time.dh_today().
+    The historical table is for all dates less than today.
+
+    Args:
+        namespace: The namespace of the table.
+        table_name: The name of the table.
+
+    Returns:
+        A CombinedTable object.
+    """
+    # noinspection PyUnusedLocal
+    date = dh_today()
+    hist = db.historical_table(namespace, table_name).where("Date < date")
+    live = db.live_table(namespace, table_name).where("Date = date")
+    return CombinedTable(hist, live)
+
+
+
+ct = combined_table("FeedOS", "EquityQuoteL1")
+live = ct.live
+hist = ct.historical
+comb = ct.combined
+# print(ct.is_replay) # Method does not exist
+print(ct.is_blink)
+f = ct.where("Date > `2024-04-09`")
+fc = f.combined
+h = f.head(3)
+
+f2 = f.where("Date < `2024-04-11`")
+fc2 = f2.combined
+h2 = f2.head(3)

--- a/examples/misc/dhe_combined_hist_live_table.py
+++ b/examples/misc/dhe_combined_hist_live_table.py
@@ -1,7 +1,7 @@
 
 """ A package that provides a CombinedTable class that combines a historical and live table into a single table."""
 
-from typing import Union, Sequence
+from typing import Union, Sequence, Optional
 from deephaven_enterprise.database import db
 from deephaven import merge
 from deephaven.table import Table, Filter
@@ -14,26 +14,38 @@ class CombinedTable:
     Overrides of table methods are provided to optimize performance.
     If a performance optimizing override is not provided, the method call is delegated to the combined table.
     """
-    def __init__(self, hist: Table, live: Table):
-        self._historical = hist
-        self._live = live
+    def __init__(self, hist: Table, live: Table, hist_filters: Sequence[str] = None, live_filters: Sequence[str] = None):
+        self._historical_raw = hist
+        self._live_raw = live
+        self._hist_filters = hist_filters
+        self._live_filters = live_filters
+        self._historical = None
+        self._live = None
         self._combined = None
 
     @property
     def historical(self):
         """ The historical table."""
+        if not self._historical:
+            self._historical = self._historical_raw.where(self._hist_filters) \
+                if self._hist_filters else self._historical_raw
+
         return self._historical
 
     @property
     def live(self):
         """ The live table."""
+        if not self._live:
+            self._live = self._live_raw.where(self._live_filters) \
+                if self._live_filters else self._live_raw
+
         return self._live
 
     @property
     def combined(self):
         """ The combined table."""
         if not self._combined:
-            self._combined = merge([self._historical, self._live])
+            self._combined = merge([self.historical, self.live])
 
         return self._combined
 
@@ -43,34 +55,67 @@ class CombinedTable:
         obj = args[0]
         fn = args[1]
         c = obj.combined
+        #TODO: handle converting args from the combined type to tables
         return getattr(c, fn)
+
+    @staticmethod
+    def _combine_filters(filter1: Sequence[str], filter2: Sequence[str]) -> Optional[Sequence[str]]:
+        """ Combine two sets of filters. If either filter is None, the other filter is returned."""
+        if not filter1 and not filter2:
+            return None
+        elif not filter1:
+            return filter2
+        elif not filter2:
+            return filter1
+        else:
+            return list(filter1) + list(filter2)
 
     def where(self, filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None) -> 'CombinedTable':
         print("DELEGATED: where")
+
+        if not filters:
+            return self
+
+        if isinstance(filters, str) or isinstance(filters, Filter):
+            filters = [filters]
+
+        has_filter = any(isinstance(f, Filter) for f in filters)
+
+        if has_filter:
+            return CombinedTable(
+                self.historical.where(filters),
+                self.live.where(filters),
+            )
+
+        hist_filters = self._combine_filters(self._hist_filters, filters)
+        live_filters = self._combine_filters(self._live_filters, filters)
+
         return CombinedTable(
-            self._historical.where(filters),
-            self._live.where(filters)
+            self._historical_raw,
+            self._live_raw,
+            hist_filters=hist_filters,
+            live_filters=live_filters,
         )
 
     def where_in(self, filter_table: Table, cols: Union[str, Sequence[str]]) -> 'CombinedTable':
         print("DELEGATED: where_in")
         return CombinedTable(
-            self._historical.where_in(filter_table, cols),
-            self._live.where_in(filter_table, cols)
+            self.historical.where_in(filter_table, cols),
+            self.live.where_in(filter_table, cols)
         )
 
     def where_not_in(self, filter_table: Table, cols: Union[str, Sequence[str]]) -> 'CombinedTable':
         print("DELEGATED: where_not_in")
         return CombinedTable(
-            self._historical.where_not_in(filter_table, cols),
-            self._live.where_not_in(filter_table, cols)
+            self.historical.where_not_in(filter_table, cols),
+            self.live.where_not_in(filter_table, cols)
         )
 
     def where_one_of(self, filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None) -> 'CombinedTable':
         print("DELEGATED: where_one_of")
         return CombinedTable(
-            self._historical.where_one_of(filters),
-            self._live.where_one_of(filters)
+            self.historical.where_one_of(filters),
+            self.live.where_one_of(filters)
         )
 
 
@@ -89,9 +134,9 @@ def combined_table(namespace:str, table_name:str) -> CombinedTable:
     """
     # noinspection PyUnusedLocal
     date = dh_today()
-    hist = db.historical_table(namespace, table_name).where("Date < date")
-    live = db.live_table(namespace, table_name).where("Date = date")
-    return CombinedTable(hist, live)
+    hist = db.historical_table(namespace, table_name)
+    live = db.live_table(namespace, table_name)
+    return CombinedTable(hist, live, hist_filters=["Date < date"], live_filters=["Date = date"])
 
 
 
@@ -101,9 +146,9 @@ hist = ct.historical
 comb = ct.combined
 # print(ct.is_replay) # Method does not exist
 print(ct.is_blink)
-f = ct.where("Date > `2024-04-09`")
-fc = f.combined
-h = f.head(3)
+f1 = ct.where("Date > `2024-04-09`")
+fc1 = f1.combined
+h = f1.head(3)
 
 f2 = f.where("Date < `2024-04-11`")
 fc2 = f2.combined

--- a/examples/misc/dhe_combined_hist_live_table.py
+++ b/examples/misc/dhe_combined_hist_live_table.py
@@ -1,11 +1,12 @@
 
 """ A package that provides a CombinedTable class that combines a historical and live table into a single table."""
 
-from typing import Union, Sequence, Optional
+from typing import Union, Sequence, Optional, Callable
 from deephaven_enterprise.database import db
 from deephaven import merge
 from deephaven.table import Table, Filter
 from deephaven.time import dh_today
+
 
 class CombinedTable:
     """ A class that combines a historical and live table into a single table.
@@ -14,7 +15,21 @@ class CombinedTable:
     Overrides of table methods are provided to optimize performance.
     If a performance optimizing override is not provided, the method call is delegated to the combined table.
     """
-    def __init__(self, hist: Table, live: Table, hist_filters: Sequence[str] = None, live_filters: Sequence[str] = None):
+
+    def __init__(self,
+                 hist: Table,
+                 live: Table,
+                 hist_filters: Sequence[str] = None,
+                 live_filters: Sequence[str] = None,
+                 ):
+        """ Create a CombinedTable object.
+
+        Args:
+            hist: The historical table.
+            live: The live table.
+            hist_filters: The filters to apply to the historical table.
+            live_filters: The filters to apply to the live table.
+        """
         self._historical_raw = hist
         self._live_raw = live
         self._hist_filters = hist_filters
@@ -24,7 +39,7 @@ class CombinedTable:
         self._combined = None
 
     @property
-    def historical(self):
+    def historical(self) -> Table:
         """ The historical table."""
         if not self._historical:
             self._historical = self._historical_raw.where(self._hist_filters) \
@@ -33,7 +48,7 @@ class CombinedTable:
         return self._historical
 
     @property
-    def live(self):
+    def live(self) -> Table:
         """ The live table."""
         if not self._live:
             self._live = self._live_raw.where(self._live_filters) \
@@ -42,21 +57,38 @@ class CombinedTable:
         return self._live
 
     @property
-    def combined(self):
+    def combined(self) -> Table:
         """ The combined table."""
         if not self._combined:
             self._combined = merge([self.historical, self.live])
 
         return self._combined
 
+    @property
+    def apply(self) -> 'CombinedTable':
+        """ The CombinedTable with the filters fully applied."""
+        return CombinedTable(self.historical, self.live)
+
+    @staticmethod
+    def _args_to_table_decorator(fn: Callable) -> Callable:
+        """ Decorator to convert function arguments from CombinedTable to Table objects."""
+        def wrapper(*args, **kwargs):
+            # TODO: remove print statements
+            print(f"WRAPPER: {args}")
+            args_new = [arg.combined if isinstance(arg, CombinedTable) else arg for arg in args]
+            return fn(*args_new, **kwargs)
+
+        return wrapper
+
     # If the method doesn't exist in this object, delegate it to the combined table.
+    # Methods are called with other CombinedTable objects as arguments, the arguments are converted to Table objects.
     def __getattr__(*args):
         print(f"GETATTR: {args}")
         obj = args[0]
         fn = args[1]
         c = obj.combined
-        #TODO: handle converting args from the combined type to tables
-        return getattr(c, fn)
+        f = getattr(c, fn)
+        return CombinedTable._args_to_table_decorator(f)
 
     @staticmethod
     def _combine_filters(filter1: Sequence[str], filter2: Sequence[str]) -> Optional[Sequence[str]]:
@@ -70,7 +102,25 @@ class CombinedTable:
         else:
             return list(filter1) + list(filter2)
 
-    def where(self, filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None) -> 'CombinedTable':
+    def where(self,
+              filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None,
+              apply: bool = True,
+              ) -> 'CombinedTable':
+        """Applies the :meth:`~Table.where` table operation to the combined table, and produces a new CombinedTable.
+
+        Args:
+            filters (Union[str, Filter, Sequence[str], Sequence[Filter]], optional): the filter condition
+                expression(s) or Filter object(s), default is None
+            apply (bool, optional): whether to immediately apply the filters or defer the application until later,
+                default is True
+
+        Returns:
+            a new CombinedTable object
+
+        Raises:
+            DHError
+        """
+
         print("DELEGATED: where")
 
         if not filters:
@@ -90,14 +140,22 @@ class CombinedTable:
         hist_filters = self._combine_filters(self._hist_filters, filters)
         live_filters = self._combine_filters(self._live_filters, filters)
 
-        return CombinedTable(
-            self._historical_raw,
-            self._live_raw,
-            hist_filters=hist_filters,
-            live_filters=live_filters,
-        )
+        if apply:
+            return CombinedTable(
+                self._historical_raw.where(hist_filters) if hist_filters else self._historical_raw,
+                self._live_raw.where(live_filters) if live_filters else self._live_raw,
+            )
+        else:
+            return CombinedTable(
+                self._historical_raw,
+                self._live_raw,
+                hist_filters=hist_filters,
+                live_filters=live_filters,
+            )
 
     def where_in(self, filter_table: Table, cols: Union[str, Sequence[str]]) -> 'CombinedTable':
+        """Applies the :meth:`~Table.where_in` table operation to the combined table,
+        and produces a new CombinedTable."""
         print("DELEGATED: where_in")
         return CombinedTable(
             self.historical.where_in(filter_table, cols),
@@ -105,6 +163,8 @@ class CombinedTable:
         )
 
     def where_not_in(self, filter_table: Table, cols: Union[str, Sequence[str]]) -> 'CombinedTable':
+        """Applies the :meth:`~Table.where_not_in` table operation to the combined table,
+        and produces a new CombinedTable."""
         print("DELEGATED: where_not_in")
         return CombinedTable(
             self.historical.where_not_in(filter_table, cols),
@@ -112,6 +172,8 @@ class CombinedTable:
         )
 
     def where_one_of(self, filters: Union[str, Filter, Sequence[str], Sequence[Filter]] = None) -> 'CombinedTable':
+        """Applies the :meth:`~Table.where_one_of` table operation to the combined table,
+        and produces a new CombinedTable."""
         print("DELEGATED: where_one_of")
         return CombinedTable(
             self.historical.where_one_of(filters),
@@ -119,7 +181,7 @@ class CombinedTable:
         )
 
 
-def combined_table(namespace:str, table_name:str) -> CombinedTable:
+def combined_table(namespace: str, table_name: str) -> CombinedTable:
     """ Create a combined table for the given namespace and table name.
 
     The live table is for today according to deephaven.time.dh_today().
@@ -139,17 +201,16 @@ def combined_table(namespace:str, table_name:str) -> CombinedTable:
     return CombinedTable(hist, live, hist_filters=["Date < date"], live_filters=["Date = date"])
 
 
-
 ct = combined_table("FeedOS", "EquityQuoteL1")
-live = ct.live
-hist = ct.historical
-comb = ct.combined
+ct_live = ct.live
+ct_hist = ct.historical
+ct_comb = ct.combined
 # print(ct.is_replay) # Method does not exist
 print(ct.is_blink)
 f1 = ct.where("Date > `2024-04-09`")
 fc1 = f1.combined
-h = f1.head(3)
+h1 = f1.head(3)
 
-f2 = f.where("Date < `2024-04-11`")
+f2 = f1.where("Date < `2024-04-11`")
 fc2 = f2.combined
 h2 = f2.head(3)


### PR DESCRIPTION
An interface to combine historical and live table access.
This avoids merging as long as possible for performance reasons (e.g. keep indexing).