### PR TITLE
Backtester v2

### DIFF
--- a/examples/replay_orchestration/simple_worker/README.md
+++ b/examples/replay_orchestration/simple_worker/README.md
@@ -19,13 +19,13 @@ The orchestrator automatically provides:
 
 - `SIMULATION_NAME`: Unique simulation identifier from config top-level `name` field
 - `SIMULATION_DATE`: The date being processed (YYYY-MM-DD) - also available via [`dh_today()`](https://docs.deephaven.io/core/pydoc/code/deephaven.time.html#deephaven.time.dh_today)
-- `WORKER_ID`: The worker's ID (0 to NUM_WORKERS-1) for partitioning data
-- `NUM_WORKERS`: Total number of workers per date
+- `PARTITION_ID`: The partition ID (0 to NUM_PARTITIONS-1) for partitioning data
+- `NUM_PARTITIONS`: Total number of partitions per date
 
 From `config.yaml` env section:
 
-- `OUTPUT_TABLE`: Name of the output table
 - `LOG_LEVEL`: Logging level
+- `CUSTOM_MESSAGE`: Example custom parameter (demonstrates how to pass configuration to workers)
 
 ## Configuration
 
@@ -33,7 +33,7 @@ See `config.yaml` for the complete orchestrator configuration. Key settings:
 
 ```yaml
 execution:
-  num_workers: 2              # Creates 2 workers per date
+  num_partitions: 2           # Creates 2 partitions per date
   
 dates:
   start: "2024-01-01"
@@ -41,7 +41,7 @@ dates:
   weekdays_only: true         # Only Mon-Fri (5 weekdays in this range)
 ```
 
-This creates 2 workers per date × 5 weekdays = 10 total sessions.
+This creates 2 partitions per date × 5 weekdays = 10 total sessions.
 
 ## Running
 
@@ -55,17 +55,30 @@ replay-orchestrator --config simple_worker/config.yaml
 
 Each session prints to console:
 
-- All environment variables (SIMULATION_DATE, WORKER_ID, NUM_WORKERS, custom vars)
-- Comparison of SIMULATION_DATE vs `dh_today()` to verify replay date
+- `SIMULATION_NAME`: The simulation identifier
+- `SIMULATION_DATE`: The date being processed
+- `dh_today()`: Comparison to verify replay date matches
+- `PARTITION_ID`: This partition's ID
+- `NUM_PARTITIONS`: Total number of partitions per date
+- `CUSTOM_MESSAGE`: The custom message from config
 - Status messages confirming execution
 
-The script also creates an in-memory table (`worker_status`) to demonstrate basic Deephaven table creation, but **does not publish or persist it**. This is intentional - the example is purely for verification.
+The script also creates an in-memory table (`worker_status`) with the following columns:
+
+- `Date`: The simulation date
+- `PartitionID`: This partition's ID
+- `NumPartitions`: Total partitions per date
+- `Status`: Always "RUNNING" in this example
+- `Message`: Descriptive message showing partition and date
+- `CustomMessage`: The custom message from config
+
+This table is **not published or persisted** - it's purely for demonstration purposes.
 
 ## Verification
 
 After running, check the orchestrator console output to verify:
 
-- All 10 sessions (2 workers × 5 weekdays) were created
+- All 10 sessions (2 partitions × 5 weekdays) were created
 - Each session completed successfully
 - No failures reported
 - Exit code 0 (success)

--- a/examples/replay_orchestration/simple_worker/config.yaml
+++ b/examples/replay_orchestration/simple_worker/config.yaml
@@ -8,7 +8,7 @@ deephaven:
   
 execution:
   worker_script: "simple_worker.py"
-  num_workers: 2
+  num_partitions: 2
   max_concurrent_sessions: 10
   
 replay:
@@ -24,5 +24,5 @@ dates:
   weekdays_only: true
   
 env:
-  OUTPUT_TABLE: "simple_results"
   LOG_LEVEL: "INFO"
+  CUSTOM_MESSAGE: "Hello from simple worker example!"

--- a/examples/replay_orchestration/simple_worker/simple_worker.py
+++ b/examples/replay_orchestration/simple_worker/simple_worker.py
@@ -5,25 +5,26 @@ from deephaven.time import dh_today
 
 simulation_name = os.getenv("SIMULATION_NAME")
 simulation_date = os.getenv("SIMULATION_DATE")
-worker_id = int(os.getenv("WORKER_ID", "0"))
-num_workers = int(os.getenv("NUM_WORKERS", "1"))
-output_table = os.getenv("OUTPUT_TABLE", "worker_results")
+partition_id = int(os.getenv("PARTITION_ID"))
+num_partitions = int(os.getenv("NUM_PARTITIONS"))
 log_level = os.getenv("LOG_LEVEL", "INFO")
+custom_message = os.getenv("CUSTOM_MESSAGE")
 
 print(f"[{log_level}] Simple Worker Started")
 print(f"[{log_level}] Simulation Name: {simulation_name}")
 print(f"[{log_level}] Simulation Date: {simulation_date}")
 print(f"[{log_level}] dh_today(): {dh_today()}")
-print(f"[{log_level}] Worker ID: {worker_id}")
-print(f"[{log_level}] Number of Workers: {num_workers}")
-print(f"[{log_level}] Output Table: {output_table}")
+print(f"[{log_level}] Partition ID: {partition_id}")
+print(f"[{log_level}] Number of Partitions: {num_partitions}")
+print(f"[{log_level}] Custom Message: {custom_message}")
 
 worker_status = new_table([
     string_col("Date", [simulation_date]),
-    int_col("WorkerID", [worker_id]),
-    int_col("NumWorkers", [num_workers]),
+    int_col("PartitionID", [partition_id]),
+    int_col("NumPartitions", [num_partitions]),
     string_col("Status", ["RUNNING"]),
-    string_col("Message", [f"Worker {worker_id} processing date {simulation_date}"])
+    string_col("Message", [f"Partition {partition_id} processing date {simulation_date}"]),
+    string_col("CustomMessage", [custom_message])
 ])
 
 print(f"[{log_level}] Simple Worker Completed Successfully")

--- a/examples/replay_orchestration/trading_simulation/README.md
+++ b/examples/replay_orchestration/trading_simulation/README.md
@@ -4,7 +4,7 @@ A market maker simulation based on mean-reversion strategy, designed to backtest
 
 ## Overview
 
-This example implements a complete trading simulation based on [`examples/finance/simulated_market_maker`](../../finance/simulated_market_maker). It demonstrates how to run large-scale backtests by partitioning stocks across multiple workers and processing historical dates in parallel.
+This example implements a complete trading simulation based on [`examples/finance/simulated_market_maker`](../../finance/simulated_market_maker). It demonstrates how to run large-scale backtests by partitioning stocks across multiple partitions and processing historical dates in parallel.
 
 ## Implementation
 
@@ -17,31 +17,31 @@ Mean-reversion market making:
 - Sell when bid price rises above (predicted price + 1 SD)
 - Manage risk through per-symbol position limits
 
-### Worker Partitioning
+### Data Partitioning
 
-Each worker processes a subset of stocks:
+Each partition processes a subset of stocks:
 
 ```python
-worker_id = int(os.getenv("WORKER_ID"))      # 0-9 for this date
-num_workers = int(os.getenv("NUM_WORKERS"))  # 10 workers per date
+partition_id = int(os.getenv("PARTITION_ID"))      # 0-1 for this date
+num_partitions = int(os.getenv("NUM_PARTITIONS"))  # 2 partitions per date
 
 # Symbols are distributed using hash-based partitioning
-my_symbols = all_symbols.where(f"Sym.hashCode() % {num_workers} == {worker_id}")
+my_symbols = all_symbols.where(f"Sym.hashCode() % {num_partitions} == {partition_id}")
 ```
 
 **Note**: This example uses 10 hardcoded symbols (AAPL, GOOG, MSFT, etc.) for demonstration. To scale to larger universes like SP500, modify the `all_symbols` table in `trading_simulation.py`.
 
 ### Configuration
 
-This example is configured for large-scale backtesting:
+Key configuration settings:
 
 ```yaml
 execution:
-  num_workers: 10              # 10 workers per date (each processes a subset of stocks)
-  max_concurrent_sessions: 20  # Max total sessions running concurrently
+  num_partitions: 2            # 2 partitions per date (each processes a subset of stocks)
+  max_concurrent_sessions: 10  # Max total sessions running concurrently
   
 replay:
-  heap_size_gb: 16.0           # More RAM for trading simulation
+  heap_size_gb: 16.0           # RAM allocated per session
   replay_speed: 100.0          # 100x speed for faster backtesting
   
 dates:
@@ -50,7 +50,9 @@ dates:
   weekdays_only: true          # 250 trading days
 ```
 
-This creates **10 workers per date × 250 days = 2,500 total replay sessions**.
+This creates **2 partitions per date × 250 days = 500 total replay sessions**.
+
+**Note**: For larger-scale backtesting, increase `num_partitions` (e.g., to 10 for 2,500 sessions) and adjust `max_concurrent_sessions` based on your server capacity.
 
 ### Environment Variables
 
@@ -64,8 +66,8 @@ Auto-generated:
 
 - `SIMULATION_NAME`: Unique identifier for the simulation run
 - `SIMULATION_DATE`: Date being simulated - also available via [`dh_today()`](https://docs.deephaven.io/core/pydoc/code/deephaven.time.html#deephaven.time.dh_today)
-- `WORKER_ID`: Worker partition ID (0 to NUM_WORKERS-1) - this example uses it for stock partitioning
-- `NUM_WORKERS`: Total workers per date
+- `PARTITION_ID`: Partition ID (0 to NUM_PARTITIONS-1) - this example uses it for stock partitioning
+- `NUM_PARTITIONS`: Total partitions per date
 
 ## Prerequisites
 
@@ -83,13 +85,13 @@ See the [main README](../README.md) for setup instructions. This example require
 replay-orchestrator --config trading_simulation/config.yaml
 ```
 
-This creates 2,500 sessions (10 workers × 250 trading days) and writes results to partitioned user tables in the `ExampleReplayTradingSim` namespace. Tables are auto-created on first write.
+This creates 500 sessions (2 partitions × 250 trading days) and writes results to partitioned user tables in the `ExampleReplayTradingSim` namespace. Tables are auto-created on first write.
 
 ## Output Tables
 
 Results are written to partitioned user tables in the namespace specified by `OUTPUT_NAMESPACE` (default: `"ExampleReplayTradingSim"`):
 
-- **`TradingSimTrades`**: All executed trades with Date, Timestamp, Symbol, Price, Size, WorkerID
+- **`TradingSimTrades`**: All executed trades with Date, Timestamp, Symbol, Price, Size, PartitionID
 - **`TradingSimPositions`**: Current positions by symbol (cumulative shares held)
 - **`TradingSimPnl`**: Profit and loss calculations per symbol
 - **`TradingSimPreds`**: Price predictions with EMA-based buy/sell thresholds
@@ -97,7 +99,7 @@ Results are written to partitioned user tables in the namespace specified by `OU
 - **`TradingSimExecutions`**: Periodic snapshots with action codes
 - **`TradingSimSummary`**: Aggregated trade counts and total shares by symbol
 
-All tables include partition columns: `SimulationName`, `WorkerID`, `Date`
+All tables include partition columns: `SimulationName`, `PartitionID`, `Date`
 
 ## Querying Results
 
@@ -123,8 +125,8 @@ To delete all simulation data: `delete_all_tables()`
 After completion, you'll have:
 
 - Historical trades across a full year (250 trading days)
-- 2,500 total sessions (10 workers × 250 days)
-- Trades partitioned by date and worker
+- 500 total sessions (2 partitions × 250 days)
+- Trades partitioned by date and partition
 - Daily PnL by symbol
 - Position history
 - Strategy performance metrics
@@ -133,9 +135,9 @@ All data will be queryable in Deephaven for analysis and visualization.
 
 ## Key Features
 
-**Worker Partitioning**: Symbols are distributed across workers using hash-based partitioning:
+**Data Partitioning**: Symbols are distributed across partitions using hash-based partitioning:
 ```python
-my_symbols = all_symbols.where(f"Sym.hashCode() % {num_workers} == {worker_id}")
+my_symbols = all_symbols.where(f"Sym.hashCode() % {num_partitions} == {partition_id}")
 ```
 
 **Mean-Reversion Strategy**:
@@ -145,9 +147,9 @@ my_symbols = all_symbols.where(f"Sym.hashCode() % {num_workers} == {worker_id}")
 - Position limits prevent excessive exposure
 
 **Replay Data**: Uses FeedOS `EquityQuoteL1` table filtered for:
-- Current replay date via `today()`
+- Current replay date via `dh_today()`
 - Valid bid/ask quotes (size > 0)
-- Symbols assigned to this worker
+- Symbols assigned to this partition
 
 **Trade Execution**: Evaluates every 10 seconds via `snapshot_when()` and executes based on market conditions and position limits.
 
@@ -161,6 +163,6 @@ To adapt for your use case:
 
 1. **Change stock universe**: Modify the `all_symbols` table in `trading_simulation.py`
 2. **Adjust strategy parameters**: Update `MAX_POSITION_DOLLARS`, `EMA_DECAY_TIME`, `LOT_SIZE` in `config.yaml`
-3. **Scale workers**: Increase `num_workers` to process more symbols in parallel
+3. **Scale partitions**: Increase `num_partitions` to process more symbols in parallel
 4. **Adjust date range**: Modify `dates.start` and `dates.end` in `config.yaml`
 5. **Speed up replay**: Increase `replay_speed` for faster backtesting (currently 100x)

--- a/examples/replay_orchestration/trading_simulation/analyze_trading_results.py
+++ b/examples/replay_orchestration/trading_simulation/analyze_trading_results.py
@@ -1,0 +1,734 @@
+"""
+Trading Simulation Results Analysis Script
+
+This script provides quantitative analysis functions for trading simulation results.
+Run this script in the Deephaven IDE console after the replay orchestration completes
+and the simulation output tables are available.
+
+HOW TO USE:
+    1. Run your trading simulation using the replay orchestrator
+    2. Wait for completion (check orchestrator logs)
+    3. In Deephaven IDE console, run: exec(open('analyze_trading_results.py').read())
+    4. Call analysis functions with your simulation name from config.yaml
+
+Expected Input Tables (created by trading simulation in ExampleReplayTradingSim namespace):
+    - TradingSimTrades: Individual trade executions
+        Columns: Date, Timestamp, Sym, Price, Size, PartitionID, SimulationName
+        Size is positive for buys, negative for sells
+    
+    - TradingSimPnl: Daily profit/loss by symbol
+        Columns: Date, Sym, PnL, SimulationName
+        PnL is the realized profit or loss for that symbol on that date
+    
+    - TradingSimPositions: Position snapshots showing holdings
+        Columns: Sym, Position, SimulationName
+        Position is the number of shares held (can be negative for short positions)
+    
+    - TradingSimExecutions: Trading signals/decisions
+        Columns: Date, Timestamp, Sym, Action, SimulationName
+        Action can be: BUY, SELL, NO_TRADE, or other strategy-specific values
+    
+    - TradingSimSummary: High-level summary by symbol
+        Columns: Sym, TradeCount, TotalShares, SimulationName
+
+Analysis Functions:
+    - get_summary(): Start here! High-level overview with best/worst performers
+    - analyze_pnl(): Profit/loss analysis with risk metrics (Sharpe ratio, drawdown, win rate)
+    - analyze_trades(): Trade execution statistics, turnover, buy/sell patterns
+    - analyze_by_symbol(): Deep dive into a specific stock's performance
+    - analyze_by_date(): Examine activity on a specific trading day
+    - analyze_positions(): Position sizing and distribution analysis
+    - analyze_executions(): Trading signal generation patterns
+
+Key Metrics Explained:
+    - Sharpe Ratio: Risk-adjusted return (higher is better, >1 is good, >2 is excellent)
+    - Max Drawdown: Largest peak-to-trough decline (lower absolute value is better)
+    - Win Rate: Percentage of profitable days (50%+ is positive)
+    - Turnover: Total dollar value traded (useful for transaction cost estimation)
+
+Quick Start Example:
+    sim_name = "trading_simulation"  # From your config.yaml
+    summary = get_summary(sim_name)
+    top_performers = summary["top_performers"]  # Assigns table to variable, displays in UI
+"""
+
+from typing import Dict, Optional, Any
+from deephaven import agg
+from deephaven.updateby import cum_sum, cum_max
+
+# Default namespace for output tables
+DEFAULT_NAMESPACE = "ExampleReplayTradingSim"
+
+def analyze_pnl(simulation_name: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Analyze profit and loss with risk-adjusted metrics for a specific simulation.
+    
+    This is the most important analysis function for evaluating trading strategy performance.
+    It calculates key risk metrics that professional traders use to assess strategy quality.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (from your config.yaml 'name' field)
+        output_namespace: Namespace where tables are stored (default: "ExampleReplayTradingSim")
+        
+    Returns:
+        Dictionary containing four Deephaven tables, or None if an error occurs:
+        
+        - "pnl": Raw daily P&L data filtered to this simulation only
+        
+        - "by_symbol": Performance breakdown for each stock symbol, sorted by total profit:
+            * TotalPnL: Total profit/loss for this symbol across all days
+            * TradingDays: Number of days this symbol had P&L entries
+            * WinningDays: Count of days with positive P&L (profit days)
+            * LosingDays: Count of days with negative P&L (loss days)
+            * WinRate: Percentage of profitable days (1.0 = 100% wins)
+            * AvgWin: Average profit on winning days (higher is better)
+            * AvgLoss: Average loss on losing days (closer to 0 is better)
+        
+        - "by_date": Daily aggregate P&L with running total:
+            * DailyPnL: Total profit/loss across all symbols for this date
+            * CumulativePnL: Running total of P&L over time (equity curve)
+            * SymbolCount: Number of symbols traded on this date
+        
+        - "overall": Single-row summary with key performance metrics:
+            * TotalPnL: Total profit/loss across entire simulation
+            * AvgDailyPnL: Average daily profit/loss
+            * StdDevDaily: Standard deviation of daily returns (volatility measure)
+            * SharpeRatio: Risk-adjusted return (annualized). >1 is good, >2 is excellent
+            * MaxDrawdown: Worst peak-to-trough decline. More negative = worse
+            * WinRate: Percentage of profitable days (0.5 = 50%)
+    
+    Example:
+        result = analyze_pnl("my_simulation")
+        print(f"Total P&L: {result['overall'].to_string()}")  # View summary stats
+        top_symbols = result["by_symbol"].head(10)  # Top 10 performers
+        equity_curve = result["by_date"]  # Visualize performance over time
+    """
+    print(f"[INFO] Analyzing P&L for simulation: {simulation_name}...")
+    
+    try:
+        pnl = db.get_partitioned_table(output_namespace, "TradingSimPnl") \
+            .where(f"SimulationName = `{simulation_name}`")
+        
+        # P&L by symbol with win/loss statistics
+        pnl_by_symbol = pnl.update_view([
+            "IsWin = PnL > 0",
+            "IsLoss = PnL < 0"
+        ]).agg_by([
+            agg.sum_("TotalPnL=PnL"),
+            agg.count_("TradingDays"),
+            agg.sum_("WinningDays=IsWin ? 1 : 0"),
+            agg.sum_("LosingDays=IsLoss ? 1 : 0"),
+            agg.avg_("AvgPnL=PnL"),
+            agg.avg_("AvgWin=IsWin ? PnL : null"),
+            agg.avg_("AvgLoss=IsLoss ? PnL : null")
+        ], by=["Sym"]) \
+        .update_view("WinRate = WinningDays / (double)(WinningDays + LosingDays)") \
+        .sort_descending("TotalPnL")
+        
+        # Daily P&L with cumulative
+        pnl_by_date = pnl.agg_by([
+            agg.sum_("DailyPnL=PnL"),
+            agg.count_distinct_("SymbolCount=Sym")
+        ], by=["Date"]) \
+        .sort("Date") \
+        .update_by(ops=cum_sum(cols=["CumulativePnL=DailyPnL"]))
+        
+        # Overall statistics with risk metrics
+        daily_pnl_for_stats = pnl.agg_by([agg.sum_("DailyPnL=PnL")], by=["Date"])
+        
+        total_pnl = daily_pnl_for_stats.agg_by([
+            agg.sum_("TotalPnL=DailyPnL"),
+            agg.avg_("AvgDailyPnL=DailyPnL"),
+            agg.std_("StdDevDaily=DailyPnL"),
+            agg.min_("MinDailyPnL=DailyPnL"),
+            agg.max_("MaxDailyPnL=DailyPnL"),
+            agg.count_("TradingDays"),
+            agg.sum_("WinningDays=DailyPnL > 0 ? 1 : 0")
+        ]).update_view([
+            "WinRate = WinningDays / (double)TradingDays",
+            "SharpeRatio = StdDevDaily > 0 ? (AvgDailyPnL / StdDevDaily) * sqrt(252.0) : 0.0"
+        ])
+        
+        # Calculate max drawdown from cumulative P&L
+        pnl_with_dd = pnl_by_date \
+            .update_by(ops=cum_max(cols=["RunningMax=CumulativePnL"])) \
+            .update_view("Drawdown = CumulativePnL - RunningMax")
+        
+        max_drawdown_table = pnl_with_dd.agg_by([agg.min_("MaxDrawdown=Drawdown")])
+        
+        # Join max drawdown into overall stats
+        total_pnl = total_pnl.natural_join(max_drawdown_table)
+        
+        print(f"[INFO] P&L Analysis Complete")
+        
+        return {
+            "pnl": pnl,
+            "by_symbol": pnl_by_symbol,
+            "by_date": pnl_by_date,
+            "overall": total_pnl
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to analyze P&L: {e}")
+        return None
+
+def analyze_trades(simulation_name: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Analyze trading activity including turnover and execution patterns.
+    
+    Use this function to understand trading frequency, execution costs, and position changes.
+    Helpful for identifying overtrading or execution quality issues.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (from your config.yaml 'name' field)
+        output_namespace: Namespace where tables are stored (default: "ExampleReplayTradingSim")
+        
+    Returns:
+        Dictionary containing five Deephaven tables, or None if an error occurs:
+        
+        - "trades": Raw trade records filtered to this simulation
+        
+        - "by_symbol": Trading activity by stock symbol, sorted by trade count:
+            * TradeCount: Number of trades executed for this symbol
+            * TotalShares: Total shares traded (absolute value, ignores buy/sell direction)
+            * NetShares: Net position change (positive = net bought, negative = net sold)
+            * AvgPrice: Average execution price across all trades
+            * PriceRange: Difference between highest and lowest execution price
+        
+        - "by_date": Daily trading metrics:
+            * TradeCount: Number of trades executed on this date
+            * Volume: Total shares traded (sum of absolute values)
+            * UniqueSymbols: Number of different stocks traded
+            * Turnover: Total dollar value traded (Volume × Price). Use for cost estimation
+        
+        - "by_side": Buy vs Sell comparison:
+            * Side: "BUY" or "SELL"
+            * TradeCount: Number of trades in this direction
+            * TotalShares: Total shares traded in this direction
+        
+        - "overall": Single-row aggregate statistics across all trades
+    
+    Example:
+        result = analyze_trades("my_simulation")
+        by_date = result["by_date"]  # Daily turnover for cost analysis
+        buy_sell = result["by_side"]  # Check if strategy is directionally biased
+    """
+    print(f"[INFO] Analyzing trades for simulation: {simulation_name}...")
+    
+    try:
+        trades = db.get_partitioned_table(output_namespace, "TradingSimTrades") \
+            .where(f"SimulationName = `{simulation_name}`")
+        
+        # Trade statistics by symbol with net position tracking
+        trades_by_symbol = trades.agg_by([
+            agg.count_("TradeCount"),
+            agg.sum_("TotalShares=abs(Size)"),
+            agg.sum_("NetShares=Size"),
+            agg.avg_("AvgPrice=Price"),
+            agg.min_("MinPrice=Price"),
+            agg.max_("MaxPrice=Price")
+        ], by=["Sym"]) \
+        .update_view("PriceRange = MaxPrice - MinPrice") \
+        .sort_descending("TradeCount")
+        
+        # Trade statistics by date with turnover
+        trades_by_date = trades.agg_by([
+            agg.count_("TradeCount"),
+            agg.sum_("Volume=abs(Size)"),
+            agg.count_distinct_("UniqueSymbols=Sym"),
+            agg.sum_("Turnover=abs(Size) * Price")
+        ], by=["Date"]) \
+        .sort("Date")
+        
+        # Buy vs Sell analysis
+        trades_with_side = trades.update_view("Side = Size > 0 ? `BUY` : `SELL`")
+        trades_by_side = trades_with_side.agg_by([
+            agg.count_("TradeCount"),
+            agg.sum_("TotalShares=abs(Size)")
+        ], by=["Side"])
+        
+        # Overall statistics
+        overall_stats = trades.agg_by([
+            agg.count_("TotalTrades"),
+            agg.sum_("TotalShares=abs(Size)"),
+            agg.count_distinct_("UniqueSymbols=Sym"),
+            agg.count_distinct_("TradingDays=Date")
+        ])
+        
+        print(f"[INFO] Trade Analysis Complete")
+        
+        return {
+            "trades": trades,
+            "by_symbol": trades_by_symbol,
+            "by_date": trades_by_date,
+            "by_side": trades_by_side,
+            "overall": overall_stats
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to analyze trades: {e}")
+        return None
+
+def analyze_by_symbol(simulation_name: str, symbol: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Deep dive analysis for a specific symbol with risk metrics.
+    
+    Provides comprehensive performance analysis for individual symbols including
+    trade-by-trade details, P&L evolution, and risk statistics.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (required)
+        symbol: Stock symbol to analyze (e.g., "AAPL")
+        output_namespace: Deephaven namespace containing the tables (default: DEFAULT_NAMESPACE)
+        
+    Returns:
+        Dictionary with the following keys, or None if error:
+        - "trades": All trades for this symbol
+        - "trade_timeline": Chronological trade sequence (Date, Timestamp, Price, Size)
+        - "pnl": P&L table for this symbol
+        - "daily_pnl": Daily P&L with cumulative P&L
+        - "positions": Position snapshots
+        - "position_history": Position evolution
+        - "stats": Summary statistics (TotalTrades, NetShares, AvgPrice, TotalPnL, 
+                   WinRate, SharpeRatio)
+    """
+    print(f"[INFO] Analyzing symbol {symbol} for simulation: {simulation_name}...")
+    
+    try:
+        # Get all tables for this symbol and simulation
+        trades = db.get_partitioned_table(output_namespace, "TradingSimTrades") \
+            .where([f"SimulationName = `{simulation_name}`", f"Sym = `{symbol}`"])
+        
+        pnl = db.get_partitioned_table(output_namespace, "TradingSimPnl") \
+            .where([f"SimulationName = `{simulation_name}`", f"Sym = `{symbol}`"])
+        
+        positions = db.get_partitioned_table(output_namespace, "TradingSimPositions") \
+            .where([f"SimulationName = `{simulation_name}`", f"Sym = `{symbol}`"])
+        
+        # Trade timeline
+        trade_timeline = trades.sort(["Date", "Timestamp"]) \
+            .view(["Date", "Timestamp", "Price", "Size"])
+        
+        # Daily P&L
+        daily_pnl = pnl.view(["Date", "Sym", "PnL"]) \
+            .sort("Date")
+        
+        # Position history
+        position_history = positions.view(["Sym", "Position"]) \
+            .sort("Sym")
+        
+        # Statistics with win/loss analysis and risk metrics
+        pnl_stats = pnl.update_view([
+            "IsWin = PnL > 0",
+            "IsLoss = PnL < 0"
+        ]).agg_by([
+            agg.sum_("TotalPnL=PnL"),
+            agg.count_("TradingDays"),
+            agg.sum_("WinningDays=IsWin ? 1 : 0"),
+            agg.avg_("AvgDailyPnL=PnL"),
+            agg.std_("StdDevPnL=PnL")
+        ]).update_view([
+            "WinRate = WinningDays / (double)TradingDays",
+            "SharpeRatio = StdDevPnL > 0 ? (AvgDailyPnL / StdDevPnL) * sqrt(252.0) : 0.0"
+        ])
+        
+        trade_stats = trades.agg_by([
+            agg.count_("TotalTrades"),
+            agg.sum_("NetShares=Size"),
+            agg.avg_("AvgPrice=Price")
+        ])
+        
+        # Combine trade and P&L stats
+        stats = trade_stats.natural_join(pnl_stats)
+        
+        # Add cumulative P&L to daily_pnl
+        daily_pnl_with_cumsum = daily_pnl.update_by(ops=cum_sum(cols=["CumulativePnL=PnL"]))
+        
+        print(f"[INFO] Symbol {symbol} Analysis Complete")
+        
+        return {
+            "trades": trades,
+            "trade_timeline": trade_timeline,
+            "pnl": pnl,
+            "daily_pnl": daily_pnl_with_cumsum,
+            "positions": positions,
+            "position_history": position_history,
+            "stats": stats
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to analyze symbol {symbol}: {e}")
+        return None
+
+def analyze_by_date(simulation_name: str, date: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Analyze trading activity and performance for a specific date.
+    
+    Useful for investigating daily behavior and identifying unusual trading patterns.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (required)
+        date: Date to analyze in YYYY-MM-DD format (e.g., "2024-01-15")
+        output_namespace: Deephaven namespace containing the tables (default: DEFAULT_NAMESPACE)
+        
+    Returns:
+        Dictionary with the following keys, or None if error:
+        - "trades": All trades on this date
+        - "trades_by_symbol": Per-symbol activity (TradeCount, TotalShares)
+        - "pnl": P&L for this date
+        - "pnl_by_symbol": Per-symbol P&L sorted by performance
+        - "timeline": Chronological trade sequence (Timestamp, Sym, Price, Size)
+        - "trade_stats": Overall statistics for the day
+        - "pnl_stats": P&L statistics for the day
+    """
+    print(f"[INFO] Analyzing date {date} for simulation: {simulation_name}...")
+    
+    try:
+        # Get all tables for this date and simulation
+        trades = db.get_partitioned_table(output_namespace, "TradingSimTrades") \
+            .where([f"SimulationName = `{simulation_name}`", f"Date = `{date}`"])
+        
+        pnl = db.get_partitioned_table(output_namespace, "TradingSimPnl") \
+            .where([f"SimulationName = `{simulation_name}`", f"Date = `{date}`"])
+        
+        # Trade activity by symbol
+        trades_by_symbol = trades.agg_by([
+            agg.count_("TradeCount"),
+            agg.sum_("TotalShares=abs(Size)")
+        ], by=["Sym"]) \
+        .sort_descending("TradeCount")
+        
+        # P&L by symbol
+        pnl_by_symbol = pnl.view(["Sym", "PnL"]) \
+            .sort_descending("PnL")
+        
+        # Trade timeline
+        trade_timeline = trades.sort("Timestamp") \
+            .view(["Timestamp", "Sym", "Price", "Size"])
+        
+        # Statistics
+        stats = trades.agg_by([
+            agg.count_("TotalTrades"),
+            agg.count_distinct_("UniqueSymbols=Sym"),
+            agg.sum_("NetShares=Size")
+        ])
+        
+        pnl_stats = pnl.agg_by([
+            agg.sum_("TotalPnL=PnL"),
+            agg.avg_("AvgPnL=PnL")
+        ])
+        
+        print(f"[INFO] Date {date} Analysis Complete")
+        
+        return {
+            "trades": trades,
+            "trades_by_symbol": trades_by_symbol,
+            "pnl": pnl,
+            "pnl_by_symbol": pnl_by_symbol,
+            "timeline": trade_timeline,
+            "trade_stats": stats,
+            "pnl_stats": pnl_stats
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to analyze date {date}: {e}")
+        return None
+
+def analyze_positions(simulation_name: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Analyze position sizing and distribution across the simulation.
+    
+    Helps evaluate position management and sizing discipline. Useful for identifying
+    concentration risk and ensuring appropriate position limits.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (required)
+        output_namespace: Deephaven namespace containing the tables (default: DEFAULT_NAMESPACE)
+        
+    Returns:
+        Dictionary with the following keys, or None if error:
+        - "positions": All position snapshots
+        - "final_positions": Ending positions (non-zero only), sorted by size
+        - "by_symbol": Position statistics per symbol (AvgPosition, MinPosition, MaxPosition)
+        - "overall": Aggregate position statistics (UniqueSymbols, AvgPosition, MaxPosition)
+    """
+    print(f"[INFO] Analyzing positions for simulation: {simulation_name}...")
+    
+    try:
+        positions = db.get_partitioned_table(output_namespace, "TradingSimPositions") \
+            .where(f"SimulationName = `{simulation_name}`")
+        
+        # Final positions by symbol
+        final_positions = positions.last_by(["Sym"]) \
+            .view(["Sym", "Position"]) \
+            .where("Position != 0") \
+            .update_view("AbsPosition = abs(Position)") \
+            .sort_descending("AbsPosition")
+        
+        # Position statistics
+        position_stats = positions.agg_by([
+            agg.avg_("AvgPosition=Position"),
+            agg.min_("MinPosition=Position"),
+            agg.max_("MaxPosition=Position"),
+            agg.count_("Observations")
+        ], by=["Sym"]) \
+        .update_view("AbsAvgPosition = abs(AvgPosition)") \
+        .sort_descending("AbsAvgPosition")
+        
+        # Overall statistics
+        overall_stats = positions.agg_by([
+            agg.count_distinct_("UniqueSymbols=Sym"),
+            agg.avg_("AvgPosition=abs(Position)"),
+            agg.max_("MaxPosition=abs(Position)")
+        ])
+        
+        print(f"[INFO] Position Analysis Complete")
+        
+        return {
+            "positions": positions,
+            "final_positions": final_positions,
+            "by_symbol": position_stats,
+            "overall": overall_stats
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to analyze positions: {e}")
+        return None
+
+def analyze_executions(simulation_name: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Analyze trading signals and execution effectiveness.
+    
+    Evaluates how often different trading actions occurred and their distribution
+    across symbols and dates. Useful for understanding signal generation patterns.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (required)
+        output_namespace: Deephaven namespace containing the tables (default: DEFAULT_NAMESPACE)
+        
+    Returns:
+        Dictionary with the following keys, or None if error:
+        - "executions": All execution records
+        - "by_action": Breakdown by action type (BUY, SELL, NO_TRADE, etc.)
+        - "by_symbol": Per-symbol action counts (TotalActions, BuyActions, SellActions, NoTradeActions)
+        - "by_date": Daily action patterns (TotalActions, UniqueSymbols)
+        - "overall": Aggregate execution statistics
+    """
+    print(f"[INFO] Analyzing executions for simulation: {simulation_name}...")
+    
+    try:
+        executions = db.get_partitioned_table(output_namespace, "TradingSimExecutions") \
+            .where(f"SimulationName = `{simulation_name}`")
+        
+        # Action counts
+        actions_by_type = executions.agg_by([
+            agg.count_("ActionCount")
+        ], by=["Action"]) \
+        .sort_descending("ActionCount")
+        
+        # Actions by symbol
+        actions_by_symbol = executions.agg_by([
+            agg.count_("TotalActions"),
+            agg.sum_("BuyActions=Action == `BUY` ? 1 : 0"),
+            agg.sum_("SellActions=Action == `SELL` ? 1 : 0"),
+            agg.sum_("NoTradeActions=Action == `NO_TRADE` ? 1 : 0")
+        ], by=["Sym"]) \
+        .sort_descending("TotalActions")
+        
+        # Actions by date
+        actions_by_date = executions.agg_by([
+            agg.count_("TotalActions"),
+            agg.count_distinct_("UniqueSymbols=Sym")
+        ], by=["Date"]) \
+        .sort("Date")
+        
+        # Overall statistics
+        overall_stats = executions.agg_by([
+            agg.count_("TotalExecutions"),
+            agg.count_distinct_("UniqueDates=Date"),
+            agg.count_distinct_("UniqueSymbols=Sym")
+        ])
+        
+        print(f"[INFO] Execution Analysis Complete")
+        
+        return {
+            "executions": executions,
+            "by_action": actions_by_type,
+            "by_symbol": actions_by_symbol,
+            "by_date": actions_by_date,
+            "overall": overall_stats
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to analyze executions: {e}")
+        return None
+
+def get_summary(simulation_name: str, output_namespace: str = DEFAULT_NAMESPACE) -> Optional[Dict[str, Any]]:
+    """
+    Get high-level summary with performance rankings - START HERE!
+    
+    This is the recommended first function to call when analyzing simulation results.
+    It provides a quick overview of what happened and highlights the best/worst performers.
+    
+    Args:
+        simulation_name: Name of the simulation to analyze (from your config.yaml 'name' field)
+        output_namespace: Namespace where tables are stored (default: "ExampleReplayTradingSim")
+        
+    Returns:
+        Dictionary containing eight items (3 raw tables + 5 summary tables), or None if error:
+        
+        - "trades": All trade records for this simulation (unfiltered raw data)
+        - "pnl": All P&L records for this simulation (unfiltered raw data)
+        - "summary": All summary records for this simulation (unfiltered raw data)
+        
+        - "trade_stats": Single-row summary of trading activity:
+            * TotalTrades: Total number of trades executed
+            * TotalShares: Total shares traded (sum of absolute values)
+            * UniqueSymbols: Number of different stocks traded
+            * TradingDays: Number of days with trading activity
+        
+        - "pnl_stats": Single-row summary of P&L performance:
+            * TotalPnL: Total profit/loss across entire simulation
+            * AvgPnL: Average P&L per record
+            * MinPnL: Worst single P&L record (most negative)
+            * MaxPnL: Best single P&L record (most positive)
+        
+        - "summary_stats": Single-row aggregate from summary table
+        
+        - "top_performers": Top 5 symbols ranked by total P&L (best performers)
+        - "bottom_performers": Bottom 5 symbols ranked by total P&L (worst performers)
+    
+    Example:
+        summary = get_summary("my_simulation")
+        
+        # Quick overview
+        print("Trade Stats:")
+        print(summary["trade_stats"].to_string())
+        
+        # Identify winners and losers
+        winners = summary["top_performers"]  # Investigate these further
+        losers = summary["bottom_performers"]  # Understand what went wrong
+    """
+    print(f"[INFO] Generating summary for simulation: {simulation_name}...")
+    
+    try:
+        # Get basic stats from each table for this simulation
+        trades = db.get_partitioned_table(output_namespace, "TradingSimTrades") \
+            .where(f"SimulationName = `{simulation_name}`")
+        pnl = db.get_partitioned_table(output_namespace, "TradingSimPnl") \
+            .where(f"SimulationName = `{simulation_name}`")
+        summary = db.get_partitioned_table(output_namespace, "TradingSimSummary") \
+            .where(f"SimulationName = `{simulation_name}`")
+        
+        # Trade statistics
+        trade_stats = trades.agg_by([
+            agg.count_("TotalTrades"),
+            agg.sum_("TotalShares=abs(Size)"),
+            agg.count_distinct_("UniqueSymbols=Sym"),
+            agg.count_distinct_("TradingDays=Date")
+        ])
+        
+        # P&L statistics
+        pnl_stats = pnl.agg_by([
+            agg.sum_("TotalPnL=PnL"),
+            agg.avg_("AvgPnL=PnL"),
+            agg.min_("MinPnL=PnL"),
+            agg.max_("MaxPnL=PnL")
+        ])
+        
+        # Summary statistics
+        summary_stats = summary.agg_by([
+            agg.sum_("TotalTrades=TradeCount"),
+            agg.sum_("TotalShares"),
+            agg.count_distinct_("UniqueSymbols=Sym")
+        ])
+        
+        # Top performers
+        top_pnl = pnl.agg_by([agg.sum_("TotalPnL=PnL")], by=["Sym"]) \
+            .sort_descending("TotalPnL") \
+            .head(5)
+        
+        # Bottom performers
+        bottom_pnl = pnl.agg_by([agg.sum_("TotalPnL=PnL")], by=["Sym"]) \
+            .sort("TotalPnL") \
+            .head(5)
+        
+        print(f"[INFO] Summary generation complete")
+        
+        return {
+            "trades": trades,
+            "pnl": pnl,
+            "summary": summary,
+            "trade_stats": trade_stats,
+            "pnl_stats": pnl_stats,
+            "summary_stats": summary_stats,
+            "top_performers": top_pnl,
+            "bottom_performers": bottom_pnl
+        }
+        
+    except Exception as e:
+        print(f"[ERROR] Failed to generate summary: {e}")
+        return None
+
+# Print usage on load
+print(f"""
+================================================================================
+Trading Simulation Results Analysis
+================================================================================
+
+QUICK START:
+  1. Set your simulation name: sim_name = "trading_simulation"
+  2. Get overview: summary = get_summary(sim_name)
+  3. View results: summary["top_performers"]  # Displays in UI
+
+All functions require a simulation_name parameter (from your config.yaml 'name').
+Results are returned as dictionaries of Deephaven tables that auto-display when
+assigned to variables.
+
+AVAILABLE FUNCTIONS:
+
+  get_summary(sim_name)           - START HERE! Overview + best/worst performers
+  analyze_pnl(sim_name)           - P&L metrics (Sharpe, drawdown, win rate)
+  analyze_trades(sim_name)        - Trade statistics, turnover, buy/sell patterns
+  analyze_by_symbol(sim_name, sym)- Deep dive on a specific stock
+  analyze_by_date(sim_name, date) - Analyze a specific trading day
+  analyze_positions(sim_name)     - Position sizing and distribution
+  analyze_executions(sim_name)    - Trading signal generation patterns
+
+KEY METRICS:
+  - Sharpe Ratio: Risk-adjusted return (>1 is good, >2 is excellent)
+  - Max Drawdown: Worst decline from peak (more negative = worse)
+  - Win Rate: % of profitable days (0.5 = 50%)
+  - Turnover: Dollar value traded (for cost estimation)
+
+Default namespace: "{DEFAULT_NAMESPACE}"
+
+EXAMPLE WORKFLOW:
+
+  # Step 1: Get your simulation name from config.yaml
+  sim_name = "trading_simulation"
+  
+  # Step 2: Start with high-level summary
+  summary = get_summary(sim_name)
+  winners = summary["top_performers"]       # See best stocks
+  losers = summary["bottom_performers"]     # See worst stocks
+  
+  # Step 3: Analyze overall performance
+  pnl = analyze_pnl(sim_name)
+  overall = pnl["overall"]                  # Sharpe, drawdown, win rate
+  by_date = pnl["by_date"]                  # Equity curve over time
+  
+  # Step 4: Investigate specific stocks
+  aapl = analyze_by_symbol(sim_name, "AAPL")
+  aapl_stats = aapl["stats"]                # Performance summary
+  aapl_equity = aapl["daily_pnl"]           # P&L evolution
+  
+  # Step 5: Analyze trading patterns
+  trades = analyze_trades(sim_name)
+  turnover = trades["by_date"]              # Daily costs
+  buy_sell = trades["by_side"]              # Direction bias
+
+For detailed help, see the module docstring at the top of this file.
+
+================================================================================
+""")

--- a/examples/replay_orchestration/trading_simulation/config.yaml
+++ b/examples/replay_orchestration/trading_simulation/config.yaml
@@ -8,8 +8,8 @@ deephaven:
   
 execution:
   worker_script: "trading_simulation.py"
-  num_workers: 10
-  max_concurrent_sessions: 20
+  num_partitions: 2
+  max_concurrent_sessions: 10
   
 replay:
   heap_size_gb: 16.0

--- a/examples/replay_orchestration/trading_simulation/trading_simulation.py
+++ b/examples/replay_orchestration/trading_simulation/trading_simulation.py
@@ -16,8 +16,8 @@ Required Environment Variables:
     - SIMULATION_DATE: Date being simulated
     - QUERY_NAME: Full persistent query name
     - OUTPUT_NAMESPACE: Namespace for output user tables
-    - WORKER_ID: Worker partition ID (0 to NUM_WORKERS-1)
-    - NUM_WORKERS: Total number of workers
+    - PARTITION_ID: Partition ID (0 to NUM_PARTITIONS-1)
+    - NUM_PARTITIONS: Total number of partitions
     - MAX_POSITION_DOLLARS: Maximum position size in dollars
     - EMA_DECAY_TIME: EMA decay time window (ISO 8601 duration)
     - LOT_SIZE: Number of shares per trade
@@ -44,8 +44,8 @@ simulation_name = os.getenv("SIMULATION_NAME")
 simulation_date = os.getenv("SIMULATION_DATE")
 query_name = os.getenv("QUERY_NAME")
 output_namespace = os.getenv("OUTPUT_NAMESPACE")
-worker_id = int(os.getenv("WORKER_ID"))
-num_workers = int(os.getenv("NUM_WORKERS"))
+partition_id = int(os.getenv("PARTITION_ID"))
+num_partitions = int(os.getenv("NUM_PARTITIONS"))
 max_position_dollars = float(os.getenv("MAX_POSITION_DOLLARS"))
 ema_decay_time = os.getenv("EMA_DECAY_TIME")
 lot_size = int(os.getenv("LOT_SIZE"))
@@ -58,13 +58,13 @@ print(f"[INFO] Trading Simulation Worker Started")
 print(f"[INFO] Simulation Name: {simulation_name}")
 print(f"[INFO] Simulation Date: {simulation_date}")
 print(f"[INFO] dh_today(): {dh_today()}")
-print(f"[INFO] Worker ID: {worker_id}/{num_workers}")
+print(f"[INFO] Partition ID: {partition_id}/{num_partitions}")
 print(f"[INFO] Max Position: ${max_position_dollars}")
 print(f"[INFO] EMA Decay Time: {ema_decay_time}")
 print(f"[INFO] Lot Size: {lot_size}")
 
 ############################################################################################################
-# Define stock universe and partition by worker
+# Define stock universe and partition symbols across partitions
 ############################################################################################################
 
 all_symbols = new_table([
@@ -72,7 +72,7 @@ all_symbols = new_table([
     double_col("MaxPositionDollars", [max_position_dollars] * 10)
 ])
 
-my_symbols = all_symbols.where(f"Sym.hashCode() % {num_workers} == {worker_id}")
+my_symbols = all_symbols.where(f"Sym.hashCode() % {num_partitions} == {partition_id}")
 
 print(f"[INFO] This worker handles {my_symbols.size} symbols")
 
@@ -86,7 +86,7 @@ trades_writer = DynamicTableWriter({
     "Sym": dht.string,
     "Price": dht.float64,
     "Size": dht.int64,
-    "WorkerID": dht.int32
+    "PartitionID": dht.int32
 })
 trades = trades_writer.table
 
@@ -96,8 +96,10 @@ positions = trades.view(["Sym", "Position=Size"]).sum_by("Sym")
 # Get replay market data
 ############################################################################################################
 
+trading_date = dh_today()
+
 ticks_bid_ask = db.live_table("FeedOS", "EquityQuoteL1") \
-    .where(["Date = today()", "BidSize > 0", "AskSize > 0"]) \
+    .where(["Date = trading_date", "BidSize > 0", "AskSize > 0"]) \
     .view(["Date", "Timestamp", "Sym = LocalCodeStr", "BidPrice=Bid", "BidSize", "AskPrice=Ask", "AskSize"]) \
     .where_in(my_symbols, "Sym")
 
@@ -185,21 +187,21 @@ def simulate_trade(date, timestamp, sym, bid, ask, pred_buy, pred_sell, is_buy_a
     if not trading_active:
         if position > 0:
             # Long position - sell at bid to close
-            trades_writer.write_row(date, timestamp, sym, bid, -position, worker_id)
+            trades_writer.write_row(date, timestamp, sym, bid, -position, partition_id)
             return "CLOSE_LONG"
         elif position < 0:
             # Short position - buy at ask to close
-            trades_writer.write_row(date, timestamp, sym, ask, -position, worker_id)
+            trades_writer.write_row(date, timestamp, sym, ask, -position, partition_id)
             return "CLOSE_SHORT"
         return "TRADING_OFF"
     
     # Normal trading period
     if is_buy_active and ask < pred_buy:
-        trades_writer.write_row(date, timestamp, sym, ask, lot_size, worker_id)
+        trades_writer.write_row(date, timestamp, sym, ask, lot_size, partition_id)
         return "BUY"
     
     if is_sell_active and bid > pred_sell:
-        trades_writer.write_row(date, timestamp, sym, bid, -lot_size, worker_id)
+        trades_writer.write_row(date, timestamp, sym, bid, -lot_size, partition_id)
         return "SELL"
     
     return "NO_TRADE"
@@ -229,7 +231,7 @@ def write_partitioned_tables():
     """
     partition_updates = [
         "SimulationName = simulation_name",
-        "WorkerID = worker_id",
+        "PartitionID = partition_id",
         "Date = simulation_date"
     ]
     
@@ -245,8 +247,8 @@ def write_partitioned_tables():
     
     print(f"[INFO] Writing user tables for simulation: {simulation_name}")
     
-    # Partition key: SimulationName/WorkerID/Date
-    partition_key = f"{simulation_name}/{worker_id}/{simulation_date}"
+    # Partition key: SimulationName/Date/PartitionID
+    partition_key = f"{simulation_name}/{simulation_date}/{partition_id}"
     
     for table, table_name in tables_to_write:
         try:
@@ -263,7 +265,7 @@ def write_partitioned_tables():
 ############################################################################################################
 
 print(f"[INFO] Trading simulation running for {my_symbols.size} symbols")
-print(f"[INFO] Worker {worker_id} will write results to partitioned tables")
+print(f"[INFO] Partition {partition_id} will write results to partitioned tables")
 print(f"[INFO] Trading Simulation Worker Initialized Successfully")
 
 ############################################################################################################

--- a/examples/replay_orchestration/trading_simulation/trading_simulation.py
+++ b/examples/replay_orchestration/trading_simulation/trading_simulation.py
@@ -266,7 +266,7 @@ def write_partitioned_tables():
 
 print(f"[INFO] Trading simulation running for {my_symbols.size} symbols")
 print(f"[INFO] Partition {partition_id} will write results to partitioned tables")
-print(f"[INFO] Trading Simulation Worker Initialized Successfully")
+print(f"[INFO] Trading Simulation Partition Initialized Successfully")
 
 ############################################################################################################
 # Monitor until market close and exit

--- a/examples/replay_orchestration/trading_simulation/trading_simulation.py
+++ b/examples/replay_orchestration/trading_simulation/trading_simulation.py
@@ -74,7 +74,7 @@ all_symbols = new_table([
 
 my_symbols = all_symbols.where(f"Sym.hashCode() % {num_partitions} == {partition_id}")
 
-print(f"[INFO] This worker handles {my_symbols.size} symbols")
+print(f"[INFO] This partition handles {my_symbols.size} symbols")
 
 ############################################################################################################
 # Create simulated trade and position tables


### PR DESCRIPTION
This pull request updates the terminology and logic throughout the Replay Orchestration Framework to use "partitions" instead of "workers" when dividing parallel processing across dates. This change is reflected in documentation, configuration, environment variables, and code, ensuring consistency and clarity for users implementing parallel data processing.

**Documentation and User-Facing Changes:**

* Updated all references in `README.md` from "workers" to "partitions" (e.g., "num_workers" → "num_partitions", "worker_id" → "partition_id") to clarify that parallelization is by data partition, not by generic worker. [[1]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L3-R14) [[2]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L26-R33) [[3]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L123-R123) [[4]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L169-R169) [[5]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L199-R207) [[6]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L321-R323) [[7]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L338-R347) [[8]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L366-R366) [[9]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L384-R384) [[10]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L395-R396) [[11]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L413-R413) [[12]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L429-R433) [[13]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L453-R459) [[14]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L478-R478) [[15]](diffhunk://#diff-e60186271c525c5cabc6bf13a76b26e0969b9f7d1863c6e58edd595881ce8fd9L558-R558)

**Code and Configuration Changes:**

* Changed all code logic, variable names, and config keys in `replay_orchestrator.py` from "workers" to "partitions", including session keying, validation, and logging. [[1]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L5-R5) [[2]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L61-R61) [[3]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L74-R74) [[4]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L134-R134) [[5]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L143-R143) [[6]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L217-R223) [[7]](diffhunk://#diff-3691ae8c32e83a2dd2068a6c70eacdb235454a3a4d66f021758b7d5294f8f966L405-R424)

These changes improve clarity for users, making it explicit that parallelization is achieved by dividing data into partitions rather than by assigning generic worker processes.